### PR TITLE
fix: remove 10m operation timeout regression (v0.2.0)

### DIFF
--- a/pkg/cloudsql/cloudsql.go
+++ b/pkg/cloudsql/cloudsql.go
@@ -152,7 +152,7 @@ func ExportCloudSQLDatabase(ctx context.Context, sqlAdminSvc *sqladmin.Service, 
 			return err
 		}
 
-		err = WaitForSQLOperation(ctx, sqlAdminSvc, time.Minute*10, projectID, op)
+		err = WaitForSQLOperation(ctx, sqlAdminSvc, projectID, op)
 		if err != nil {
 			return err
 		}
@@ -161,19 +161,16 @@ func ExportCloudSQLDatabase(ctx context.Context, sqlAdminSvc *sqladmin.Service, 
 	return nil
 }
 
-func WaitForSQLOperation(ctx context.Context, sqlAdminSvc *sqladmin.Service, timeout time.Duration, gcpProject string, op *sqladmin.Operation) error {
+func WaitForSQLOperation(ctx context.Context, sqlAdminSvc *sqladmin.Service, gcpProject string, op *sqladmin.Operation) error {
 	if op == nil {
 		return errors.New("got nil op")
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	opName := op.Name
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for operation %s: %w", opName, ctx.Err())
+			return fmt.Errorf("waiting for operation %s: %w", opName, ctx.Err())
 		default:
 			time.Sleep(time.Second * 10)
 			current, err := sqlAdminSvc.Operations.Get(gcpProject, opName).Do()


### PR DESCRIPTION
## Summary

- v0.2.0 activated a hardcoded 10-minute client-side deadline in `WaitForSQLOperation` by wrapping the parent context with `context.WithTimeout`. The same `timeout` parameter existed in v0.1.x but was dead code — so polling effectively ran as long as needed. v0.2.0 flipped it into an enforced deadline.
- Large database exports can legitimately run many hours — the 10m cap causes false `timeout waiting for operation ... context deadline exceeded` failures.
- This PR removes the in-app deadline, drops the now-unused `timeout` parameter, and leaves polling bounded by the parent context (so callers can still impose a deadline via `ctx`, and SIGTERM still propagates).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes